### PR TITLE
fix: Skip PSScriptAnalyzer install on cache hit

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Cache PowerShell modules
+        id: cache-lint-modules
         uses: actions/cache@v5
         with:
           path: ~/Documents/PowerShell/Modules
@@ -35,6 +36,7 @@ jobs:
             ${{ runner.os }}-psmodules-lint-
 
       - name: Install PSScriptAnalyzer
+        if: steps.cache-lint-modules.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           Set-PSRepository -Name PSGallery -InstallationPolicy Trusted


### PR DESCRIPTION
## Summary

- The lint job was unconditionally running `Install-Module` even when PSScriptAnalyzer was already restored from cache
- This caused `Install-Module -Force` to conflict with the already-loaded cached module, which can trigger a `NullReferenceException` in PSScriptAnalyzer
- Added `id` to the cache step and an `if` condition on the install step so it only runs on cache miss

## Test Plan

- [ ] CI lint job passes on this PR
- [ ] Verify cache hit scenario skips `Install-Module` step in the workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflow to skip redundant module installations when cached, improving pipeline efficiency and reducing build times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->