### PR TITLE
docs(build): clarify PowerShellBuild bug-workaround status

### DIFF
--- a/build.psake.ps1
+++ b/build.psake.ps1
@@ -25,16 +25,20 @@ properties {
     $PSBPreference.Test.CodeCoverage.OutputFile = '../coverage.xml'
     $PSBPreference.Test.CodeCoverage.OutputFormat = 'JaCoCo'
     $PSBPreference.Test.CodeCoverage.Files = '../ScheduledTasksManager/**/*.ps1'
-    # WORKAROUND: PowerShellBuild 0.7.3 has a bug in Test-PSBuildPester.ps1 line 118
-    # It uses [Math]::Truncate([int]$_.covered / $total) which truncates 0.886 to 0
-    # instead of 88.6%. Setting threshold to 0 until bug is fixed.
-    # See: https://github.com/psake/PowerShellBuild/issues (bug reported)
+    # Coverage threshold is enforced by Codecov, not by the local build.
+    # PowerShellBuild's Test-PSBuildPester.ps1:118 has a [Math]::Truncate(int / int)
+    # bug that displays sub-100% coverage as 0% on the console (still present in
+    # v0.8.0). The bug is display-only — the JaCoCo XML written to disk has the
+    # correct numbers and Codecov reads that XML, so coverage gating is unaffected.
+    # Threshold = 0 here just prevents the local build from acting on the bogus
+    # 0% display.
     $PSBPreference.Test.CodeCoverage.Threshold = 0.0
 
-    # PSScriptAnalyzer configuration (PowerShellBuild 0.7.3+)
-    # Disable built-in analysis due to PowerShellBuild 0.7.3 bug:
-    # Test-PSBuildScriptAnalysis.ps1 line 32-34 has typo "$_Severity" instead of "$_.Severity"
-    # causing null reference exception. We use a custom ScriptAnalysis task until fixed.
+    # Disable PSB's built-in PSScriptAnalyzer integration.
+    # Test-PSBuildScriptAnalysis.ps1:32-34 has a "$_Severity" typo (missing dot)
+    # that silently misses findings — bug still present in v0.8.0; no upstream
+    # fix PR open (only #106, which adds tests for the function). The custom
+    # ScriptAnalysis task below substitutes for it.
     $PSBPreference.Test.ScriptAnalysis.Enabled = $false
     $PSBPreference.Test.ScriptAnalysis.SettingsPath = Join-Path -Path $PSScriptRoot -ChildPath 'PSScriptAnalyzerSettings.psd1'
 }
@@ -109,9 +113,9 @@ Task -Name 'UnitTest' -Depends 'Build' -PreCondition $unitTestPreReqs -Descripti
     }
 }
 
-# Custom ScriptAnalysis task to work around PowerShellBuild 0.7.3 bug
-# Bug: Test-PSBuildScriptAnalysis.ps1 uses "$_Severity" instead of "$_.Severity" (missing dot)
-# This causes null reference exception when PSScriptAnalyzer returns results
+# Custom ScriptAnalysis task — substitute for PowerShellBuild's
+# Test-PSBuildScriptAnalysis (the "$_Severity" typo, missing dot, that silently
+# drops findings). Bug still present in v0.8.0.
 $scriptAnalysisPreReqs = {
     $result = $true
     if (-not (Get-Module -Name PSScriptAnalyzer -ListAvailable)) {

--- a/build.psake.ps1
+++ b/build.psake.ps1
@@ -34,10 +34,10 @@ properties {
     # 0% display.
     $PSBPreference.Test.CodeCoverage.Threshold = 0.0
 
-    # Disable PSB's built-in PSScriptAnalyzer integration.
+    # Disable PowerShellBuild's built-in PSScriptAnalyzer integration.
     # Test-PSBuildScriptAnalysis.ps1:32-34 has a "$_Severity" typo (missing dot)
     # that silently misses findings — bug still present in v0.8.0; no upstream
-    # fix PR open (only #106, which adds tests for the function). The custom
+    # fix pull request open (only #106, which adds tests for the function). The custom
     # ScriptAnalysis task below substitutes for it.
     $PSBPreference.Test.ScriptAnalysis.Enabled = $false
     $PSBPreference.Test.ScriptAnalysis.SettingsPath = Join-Path -Path $PSScriptRoot -ChildPath 'PSScriptAnalyzerSettings.psd1'


### PR DESCRIPTION
## Summary

Three comment blocks in `build.psake.ps1` referenced PowerShellBuild v0.7.3 bugs as `"until bug is fixed"` workarounds. As part of a wider multi-repo coverage-config alignment effort ([upstream PR #19 on `PowerShellModuleTemplate`](https://github.com/tablackburn/PowerShellModuleTemplate/pull/19)), I checked the upstream status against PowerShellBuild v0.8.0 (Feb 2026, latest):

| PSB bug | Still present in v0.8.0? | Upstream fix PR? | Status of the workaround in this repo |
|---|---|---|---|
| `Test-PSBuildPester.ps1:118` — `[Math]::Truncate(int / int)` truncates sub-100% coverage to 0 on console | ✅ yes | ❌ none | **Comment was misleading.** This bug is *display-only* — the JaCoCo XML on disk has the correct numbers and Codecov reads that XML, so coverage gating already works correctly. `Threshold = 0` here is just preventing the local build from acting on the bogus 0% console display, which is the same `"Codecov enforces threshold"` pattern the upstream template uses. |
| `Test-PSBuildScriptAnalysis.ps1:32-34` — `$_Severity` typo (missing dot) that silently misses findings | ✅ yes | ❌ none — only [#106](https://github.com/psake/PowerShellBuild/pull/106) is open, which adds tests for the function (doesn't fix the typo) | **Workaround is genuinely necessary**, just bumped version reference and noted the absent fix PR. |

## Why this is just a doc change

After checking upstream, the right move is **Path A** in the agreed scope: document the divergence rather than restructure. The custom `UnitTest` task (Integration test exclusion) and custom `ScriptAnalysis` task ($_Severity typo) are both load-bearing for separate reasons; aligning to the template's default `Test` wiring would require restructuring 17+ test files for marginal benefit.

The truncation comment was the only actually-misleading framing — it implied the workaround would be removable if the bug got fixed, but really `Threshold = 0` is the right value for this repo regardless of bug status (Codecov does the gating).

## Test plan

- [x] CI green (no code change, comment-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Clarified build documentation comments to explain code coverage display/truncation behavior and note that coverage thresholds are enforced by the external service using reported XML.
  * Updated comments describing a linter analyzer quirk and the project's workaround.
  * No executable logic, configuration values, or user-facing behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->