### PR TITLE
ci: rename test job to match Unit Tests (<os>) convention

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -62,7 +62,7 @@ jobs:
           Write-Host "PSScriptAnalyzer passed with no errors"
 
   test:
-    name: Run Tests
+    name: Unit Tests (windows-latest)
     runs-on: windows-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary

- Renames the `test` job's display name from `Run Tests` to `Unit Tests (windows-latest)` so the resulting required-status-check matches the `Unit Tests (<os>)` convention used across the other PowerShellModuleTemplate-derived modules.
- Job remains Windows-only because the `ScheduledTasks` PowerShell module isn't available on Linux/macOS.

## Coordination

After this PR's CI produces the new check name, branch protection on `main` will be updated to swap required check `Run Tests` → `Unit Tests (windows-latest)`. Then this PR can merge.

## Test plan

- [x] CI runs `PSScriptAnalyzer Lint` (unchanged)
> Verified 2026-05-10: PR head 65a501c check-runs show `PSScriptAnalyzer Lint` = success.
- [x] CI runs `Unit Tests (windows-latest)` (new name) and passes
> Verified 2026-05-10: PR head 65a501c check-runs show `Unit Tests (windows-latest)` = success — new name appears as required-status-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal continuous integration configuration for improved clarity in job reporting.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal development infrastructure maintenance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tablackburn/ScheduledTasksManager/pull/36)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->