### PR TITLE
ci: rename PS_GALLERY_KEY secret reference to PSGALLERY_API_KEY

### DIFF
--- a/.github/workflows/PublishModuleToPowerShellGallery.yaml
+++ b/.github/workflows/PublishModuleToPowerShellGallery.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Publish to PSGallery
         if: steps.check_release.outputs.exists == 'false' && steps.check_psgallery.outputs.IN_GALLERY == 'False'
         env:
-          PSGALLERY_API_KEY: ${{ secrets.PS_GALLERY_KEY }}
+          PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
         run: ./build.ps1 -Task 'Publish' -Bootstrap
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary

- Updates `PublishModuleToPowerShellGallery.yaml` to read from `secrets.PSGALLERY_API_KEY` instead of `secrets.PS_GALLERY_KEY`, matching the convention established in PowerShellModuleTemplate (PR upstream-template#25).
- The env var name fed into `build.ps1` (`PSGALLERY_API_KEY`) is unchanged.
- A new `PSGALLERY_API_KEY` secret has been added with the same value as the existing `PS_GALLERY_KEY` secret, so the next publish workflow run will succeed.
- The old `PS_GALLERY_KEY` secret will be deleted after this PR merges.

## Test plan

- [x] CI passes on the standard required checks
> Verified 2026-05-10: PR head 603421d check-runs all green — PSScriptAnalyzer Lint, Unit Tests (windows-latest), GitGuardian Scan/Security Checks all success.
- [x] After merge: `PS_GALLERY_KEY` repo secret deleted
> Verified 2026-05-10: `gh secret list -R tablackburn/ScheduledTasksManager` returns CODECOV_TOKEN, GITGUARDIAN_API_KEY, HYPERV_PASSWORD, HYPERV_USERNAME, PSGALLERY_API_KEY, TS_HYPER_V_HOST, TS_OAUTH_CLIENT_ID, TS_OAUTH_SECRET — no PS_GALLERY_KEY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)