### PR TITLE
docs: update PSGallery secret reference to PSGALLERY_API_KEY

### DIFF
--- a/instructions/repository-specific.instructions.md
+++ b/instructions/repository-specific.instructions.md
@@ -179,7 +179,7 @@ The module is automatically published via GitHub Actions when:
 
 1. Version in `ScheduledTasksManager.psd1` must be incremented
 2. CI tests must pass
-3. `PS_GALLERY_KEY` secret must be configured
+3. `PSGALLERY_API_KEY` secret must be configured
 
 ### Release Process
 


### PR DESCRIPTION
## Summary

Updates the release-checklist line in `instructions/repository-specific.instructions.md` to reference `PSGALLERY_API_KEY` instead of `PS_GALLERY_KEY`.

## Context

The actual repo secret was renamed and the publish workflow already references the new name (PR #37 in this repo). This is the corresponding instruction-file update so AI agents reading the release checklist see the current secret name.

## Test plan

- [x] CI passes
> Verified 2026-05-10: PR head 8e4b437 check-runs all green — PSScriptAnalyzer Lint, Unit Tests (windows-latest), GitGuardian Scan/Security Checks all success.
- [x] Markdown renders correctly
> Verified 2026-05-10: GitHub HTML endpoint returns rendered markdown-body for instructions/repository-specific.instructions.md on main; secret reference reads `PSGALLERY_API_KEY`, no PS_GALLERY_KEY remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)