### PR TITLE
ci: graceful-skip ggshield when GITGUARDIAN_API_KEY isn't set

### DIFF
--- a/.github/workflows/ggshield.yaml
+++ b/.github/workflows/ggshield.yaml
@@ -8,12 +8,16 @@ jobs:
   scanning:
     name: GitGuardian Scan
     runs-on: ubuntu-latest
-    # Skip for Dependabot PRs - they don't have access to secrets and only update dependencies
+    # Skip Dependabot PRs (no secret access, only updates dependencies). The
+    # secret-presence check is enforced per-step via `env.GITGUARDIAN_API_KEY`
+    # below, because the `secrets` context isn't available in `if:` expressions.
     if: github.actor != 'dependabot[bot]'
+    env:
+      GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
     steps:
       - uses: actions/checkout@v6
+        if: env.GITGUARDIAN_API_KEY != ''
         with:
           fetch-depth: 0
       - uses: GitGuardian/ggshield-action@v1
-        env:
-          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+        if: env.GITGUARDIAN_API_KEY != ''


### PR DESCRIPTION
## Summary

Propagates [PowerShellModuleTemplate#28](https://github.com/tablackburn/PowerShellModuleTemplate/pull/28) to this repo. Updates `.github/workflows/ggshield.yaml` to use the env-passthrough pattern so the GitGuardian Scan job no-ops cleanly when `GITGUARDIAN_API_KEY` isn't configured, instead of failing the workflow run.

## Why

Defensive alignment with the template's new convention. This repo currently has `GITGUARDIAN_API_KEY` set, so there's no behavior change today — the gate evaluates true and the scan runs as before. The value is for any future state where the secret is rotated, removed, or unset.

## Notes

- The `secrets` context isn't available in `if:` expressions, so the gate uses job-level `env` + step-level `if: env.X != ''`.
- The explicit Dependabot actor check is kept for self-documentation, even though Dependabot PRs would now be skipped naturally by the env check (no secret access).

## Test plan

- [ ] CI passes (existing required checks)
- [ ] `GitGuardian Scan` runs (gate evaluates true here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)