### PR TITLE
style: add ValidateNotNullOrEmpty to build.ps1 -Task parameter

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -40,6 +40,7 @@ param(
                 @()
             }
         })]
+    [ValidateNotNullOrEmpty()]
     [string[]]$Task = 'default',
 
     # Bootstrap dependencies


### PR DESCRIPTION
## Summary

Adds `[ValidateNotNullOrEmpty()]` to the `$Task` parameter in `build.ps1` to match the canonical pattern from [PowerShellModuleTemplate#23](https://github.com/tablackburn/PowerShellModuleTemplate/pull/23).

Without the validator, `./build.ps1 -Task ''` and `./build.ps1 -Task `$null` slip past parameter binding and produce confusing downstream errors from psake. The validator surfaces the misuse immediately.

## Test plan

- [ ] `./build.ps1` still runs successfully (default `'default'` task)
- [ ] `./build.ps1 -Task ''` fails fast with a parameter-validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)