### PR TITLE
fix(scheduledtaskinfo): target remote CIM session and continue loop on per-task failure

### DIFF
--- a/ScheduledTasksManager/Public/Get-StmScheduledTaskInfo.ps1
+++ b/ScheduledTasksManager/Public/Get-StmScheduledTaskInfo.ps1
@@ -230,15 +230,26 @@ function Get-StmScheduledTaskInfo {
 
         foreach ($task in $scheduledTasks) {
             try {
-                $getScheduledTaskInfoParameters = @{
-                    TaskName    = $task.TaskName
-                    TaskPath    = $task.TaskPath
-                    ErrorAction = 'Stop'
+                if ($PSCmdlet.ParameterSetName -eq 'ByInputObject') {
+                    # Pipe the task object straight through so Get-ScheduledTaskInfo reuses
+                    # the CIM session the object was retrieved from. A task piped in from a
+                    # remote Get-StmScheduledTask carries its originating session; rebuilding
+                    # the call from TaskName/TaskPath (as the ByParameters path does) would
+                    # silently fall back to the local Task Scheduler and return HRESULT
+                    # 0x80070002 for tasks that only exist on the remote host.
+                    $scheduledTaskInfo = $task | Get-ScheduledTaskInfo -ErrorAction Stop
                 }
-                if ($infoCimSession) {
-                    $getScheduledTaskInfoParameters['CimSession'] = $infoCimSession
+                else {
+                    $getScheduledTaskInfoParameters = @{
+                        TaskName    = $task.TaskName
+                        TaskPath    = $task.TaskPath
+                        ErrorAction = 'Stop'
+                    }
+                    if ($infoCimSession) {
+                        $getScheduledTaskInfoParameters['CimSession'] = $infoCimSession
+                    }
+                    $scheduledTaskInfo = Get-ScheduledTaskInfo @getScheduledTaskInfoParameters
                 }
-                $scheduledTaskInfo = Get-ScheduledTaskInfo @getScheduledTaskInfoParameters
 
                 Write-Verbose "Merging properties for task '$($task.TaskName)'"
                 $mergeParameters = @{
@@ -304,7 +315,11 @@ function Get-StmScheduledTaskInfo {
 
     end {
         if ($infoCimSession) {
-            Remove-CimSession -CimSession $infoCimSession -ErrorAction SilentlyContinue
+            # -WhatIf:$false: tearing down the CIM session is connection cleanup, not a
+            # state change the caller should be able to skip via WhatIfPreference. Without
+            # this, an inherited $WhatIfPreference would leak the remote session. Matches
+            # the Remove-CimSession pattern used elsewhere in the module (see 0.11.2).
+            Remove-CimSession -CimSession $infoCimSession -ErrorAction SilentlyContinue -WhatIf:$false
         }
         Write-Verbose 'Finished Get-StmScheduledTaskInfo'
     }

--- a/ScheduledTasksManager/Public/Get-StmScheduledTaskInfo.ps1
+++ b/ScheduledTasksManager/Public/Get-StmScheduledTaskInfo.ps1
@@ -200,6 +200,19 @@ function Get-StmScheduledTaskInfo {
             }
 
             $scheduledTasks = Get-StmScheduledTask @stmScheduledTaskParameters
+
+            # Get-ScheduledTaskInfo needs a CIM session for remote hosts, otherwise it
+            # falls back to the local Task Scheduler and returns HRESULT 0x80070002 for
+            # task names that exist on the remote host but not locally.
+            $infoCimSession = $null
+            if ($ComputerName -ne 'localhost' -and $ComputerName -ne '.' -and
+                $ComputerName -ne $env:COMPUTERNAME) {
+                $infoCimSessionParameters = @{ ComputerName = $ComputerName }
+                if ($PSBoundParameters.ContainsKey('Credential')) {
+                    $infoCimSessionParameters['Credential'] = $Credential
+                }
+                $infoCimSession = New-StmCimSession @infoCimSessionParameters
+            }
         }
     }
 
@@ -217,7 +230,15 @@ function Get-StmScheduledTaskInfo {
 
         foreach ($task in $scheduledTasks) {
             try {
-                $scheduledTaskInfo = Get-ScheduledTaskInfo -TaskName $task.TaskName -TaskPath $task.TaskPath
+                $getScheduledTaskInfoParameters = @{
+                    TaskName    = $task.TaskName
+                    TaskPath    = $task.TaskPath
+                    ErrorAction = 'Stop'
+                }
+                if ($infoCimSession) {
+                    $getScheduledTaskInfoParameters['CimSession'] = $infoCimSession
+                }
+                $scheduledTaskInfo = Get-ScheduledTaskInfo @getScheduledTaskInfoParameters
 
                 Write-Verbose "Merging properties for task '$($task.TaskName)'"
                 $mergeParameters = @{
@@ -275,12 +296,16 @@ function Get-StmScheduledTaskInfo {
                     )
                 }
                 $errorRecord = New-StmError @errorRecordParameters
-                $PSCmdlet.ThrowTerminatingError($errorRecord)
+                $PSCmdlet.WriteError($errorRecord)
+                continue
             }
         }
     }
 
     end {
+        if ($infoCimSession) {
+            Remove-CimSession -CimSession $infoCimSession -ErrorAction SilentlyContinue
+        }
         Write-Verbose 'Finished Get-StmScheduledTaskInfo'
     }
 }

--- a/tests/Get-StmScheduledTaskInfo.Tests.ps1
+++ b/tests/Get-StmScheduledTaskInfo.Tests.ps1
@@ -52,6 +52,15 @@ InModuleScope -ModuleName 'ScheduledTasksManager' {
                     ScheduledTaskInfoObject = $SecondObject
                 }
             }
+
+            # The Issue-3 fix creates a CIM session for remote ComputerName values. Without
+            # mocking these, tests that pass -ComputerName 'Server01' would try to reach the
+            # real (nonexistent) host. New-MockObject returns a properly-typed CimSession
+            # so the patched code's -CimSession parameter binding succeeds.
+            Mock -CommandName New-StmCimSession -MockWith {
+                return (New-MockObject -Type 'Microsoft.Management.Infrastructure.CimSession')
+            }
+            Mock -CommandName Remove-CimSession -MockWith {}
         }
 
         It 'Should retrieve task info without parameters' {
@@ -290,7 +299,7 @@ InModuleScope -ModuleName 'ScheduledTasksManager' {
             }
         }
 
-        It 'Should throw terminating error when Get-ScheduledTaskInfo fails' {
+        It 'Should write a non-terminating error (not throw) when Get-ScheduledTaskInfo fails' {
             Mock -CommandName Get-ScheduledTaskInfo -MockWith {
                 throw 'Access Denied'
             }
@@ -301,12 +310,26 @@ InModuleScope -ModuleName 'ScheduledTasksManager' {
                 }
             }
 
-            {
-                Get-StmScheduledTaskInfo -TaskName 'ErrorTask'
-            } | Should -Throw
+            # Calling directly (not via { } | Should -Not -Throw) for two reasons:
+            #   1. If the cmdlet throws, this It fails with the exception — which is what
+            #      we want for a regression of the original ThrowTerminatingError bug.
+            #   2. A scriptblock wrapper would scope -ErrorVariable away from the outer $err.
+            $err = $null
+            $invokeParameters = @{
+                TaskName      = 'ErrorTask'
+                ErrorVariable = 'err'
+                ErrorAction   = 'SilentlyContinue'
+            }
+            Get-StmScheduledTaskInfo @invokeParameters
 
             Should -Invoke Get-ScheduledTaskInfo -Times 1 -Exactly
             Should -Invoke New-StmError -Times 1 -Exactly
+
+            # Filtered-match-count instead of total-count: Pester mock framework adds extra raw
+            # error records to $err when the mock body throws.
+            $structuredErrors = $err |
+                Where-Object { $_.FullyQualifiedErrorId -match 'ScheduledTaskInfoRetrievalFailed' }
+            @($structuredErrors).Count | Should -Be 1
         }
 
         It 'Should include task name in error message' {
@@ -320,9 +343,11 @@ InModuleScope -ModuleName 'ScheduledTasksManager' {
                 }
             }
 
-            {
-                Get-StmScheduledTaskInfo -TaskName 'ErrorTask'
-            } | Should -Throw
+            $invokeParameters = @{
+                TaskName    = 'ErrorTask'
+                ErrorAction = 'SilentlyContinue'
+            }
+            Get-StmScheduledTaskInfo @invokeParameters
 
             Should -Invoke New-StmError -Times 1 -Exactly -ParameterFilter {
                 $Message -like "*ErrorTask*"
@@ -385,6 +410,110 @@ InModuleScope -ModuleName 'ScheduledTasksManager' {
 
             $result.TaskName | Should -Be 'ConflictTask'
             $result.TaskName | Should -Not -BeOfType [hashtable]
+        }
+    }
+
+    Context 'Remote-host CIM session plumbing (Issue 3 fix a)' {
+        BeforeEach {
+            Mock -CommandName Get-StmScheduledTask -MockWith {
+                $t = [PSCustomObject]@{
+                    TaskName = 'RemoteTask'
+                    TaskPath = '\'
+                    State    = 'Ready'
+                }
+                $t.PSObject.TypeNames.Insert(0, 'Microsoft.Management.Infrastructure.CimInstance#MSFT_ScheduledTask')
+                return $t
+            }
+            Mock -CommandName New-StmCimSession -MockWith {
+                # New-MockObject yields a properly-typed CimSession so the patched code's
+                # -CimSession parameter binding on Get-ScheduledTaskInfo succeeds.
+                return (New-MockObject -Type 'Microsoft.Management.Infrastructure.CimSession')
+            }
+            Mock -CommandName Get-ScheduledTaskInfo -MockWith {
+                return [PSCustomObject]@{
+                    LastRunTime        = (Get-Date).AddHours(-1)
+                    LastTaskResult     = 0
+                    NextRunTime        = (Get-Date).AddHours(1)
+                    NumberOfMissedRuns = 0
+                }
+            }
+            Mock -CommandName Merge-Object -MockWith {
+                param($FirstObject, $SecondObject)
+                @{ TaskName = $FirstObject.TaskName; State = 'Ready' }
+            }
+            Mock -CommandName Remove-CimSession -MockWith {}
+        }
+
+        It 'Should pass -CimSession to Get-ScheduledTaskInfo when ComputerName is a remote host' {
+            Get-StmScheduledTaskInfo -ComputerName 'RemoteServer' -TaskName 'RemoteTask' | Out-Null
+            Should -Invoke Get-ScheduledTaskInfo -Times 1 -ParameterFilter {
+                $null -ne $CimSession
+            }
+        }
+
+        It 'Should NOT pass -CimSession to Get-ScheduledTaskInfo when ComputerName is localhost' {
+            Get-StmScheduledTaskInfo -ComputerName 'localhost' -TaskName 'RemoteTask' | Out-Null
+            Should -Invoke Get-ScheduledTaskInfo -Times 1 -ParameterFilter {
+                -not $PSBoundParameters.ContainsKey('CimSession')
+            }
+        }
+    }
+
+    Context 'Loop continues on per-task failure (Issue 3 fix b)' {
+        BeforeEach {
+            Mock -CommandName Get-StmScheduledTask -MockWith {
+                1..3 | ForEach-Object {
+                    $t = [PSCustomObject]@{
+                        TaskName = "Task$_"
+                        TaskPath = '\'
+                        State    = 'Ready'
+                    }
+                    $t.PSObject.TypeNames.Insert(0, 'Microsoft.Management.Infrastructure.CimInstance#MSFT_ScheduledTask')
+                    $t
+                }
+            }
+            # Use Write-Error -ErrorAction Stop instead of bare `throw` — a Pester mock body's
+            # `throw` behaves unpredictably (the exception was being captured many times via
+            # -ErrorVariable instead of going through the cmdlet's try/catch).
+            Mock -CommandName Get-ScheduledTaskInfo -ParameterFilter {
+                $TaskName -eq 'Task2'
+            } -MockWith {
+                Write-Error 'simulated CIM failure on Task2' -ErrorAction Stop
+            }
+            Mock -CommandName Get-ScheduledTaskInfo -MockWith {
+                return [PSCustomObject]@{
+                    LastRunTime        = (Get-Date).AddHours(-1)
+                    LastTaskResult     = 0
+                    NextRunTime        = (Get-Date).AddHours(1)
+                    NumberOfMissedRuns = 0
+                }
+            }
+            Mock -CommandName Merge-Object -MockWith {
+                param($FirstObject, $SecondObject)
+                @{ TaskName = $FirstObject.TaskName; State = 'Ready' }
+            }
+        }
+
+        It 'Should process remaining tasks (and write a per-task error) when one task fails' {
+            $err = $null
+            $loopParameters = @{
+                TaskName      = 'Task*'
+                ErrorVariable = 'err'
+                ErrorAction   = 'SilentlyContinue'
+            }
+            $results = Get-StmScheduledTaskInfo @loopParameters
+
+            # Core contract: loop did not abort, output contains the surviving tasks
+            @($results).Count                            | Should -Be 2
+            @($results | ForEach-Object { $_.TaskName }) | Should -Be @('Task1', 'Task3')
+
+            # And: the failing task surfaced as a structured error with the right attribution.
+            # We assert filtered-match-count rather than total-count because Pester's mock
+            # framework can add extra raw error records to $err that aren't ours.
+            $structuredErrors = $err |
+                Where-Object { $_.FullyQualifiedErrorId -match 'ScheduledTaskInfoRetrievalFailed' }
+            @($structuredErrors).Count | Should -Be 1
+            $structuredErrors[0].TargetObject | Should -Be 'Task2'
         }
     }
     }

--- a/tests/Get-StmScheduledTaskInfo.Tests.ps1
+++ b/tests/Get-StmScheduledTaskInfo.Tests.ps1
@@ -199,6 +199,37 @@ InModuleScope -ModuleName 'ScheduledTasksManager' {
 
     Context 'When retrieving task info using pipeline input' {
         BeforeEach {
+            # Build a real MSFT_ScheduledTask CimInstance so pipeline ByValue binding to
+            # Get-ScheduledTaskInfo's -InputObject succeeds. A faux PSCustomObject with an
+            # inserted type name does NOT bind by value, and Get-ScheduledTaskInfo's
+            # TaskName/TaskPath are not pipeline-by-property-name parameters. The task
+            # fields the function reads after the pipe are set as real CIM properties (the
+            # way an actual scheduled-task instance exposes them) rather than ETS members,
+            # which collide with CimInstance's built-in 'State' ScriptProperty.
+            function New-StmTestTaskCimInstance {
+                param($TaskName, $TaskPath = '\TestPath\', $State = 'Ready')
+                $newInstanceParameters = @{
+                    TypeName     = 'Microsoft.Management.Infrastructure.CimInstance'
+                    ArgumentList = @('MSFT_ScheduledTask', 'Root/Microsoft/Windows/TaskScheduler')
+                }
+                $instance = New-Object @newInstanceParameters
+                $cimPropertyValues = [ordered]@{
+                    TaskName = $TaskName
+                    TaskPath = $TaskPath
+                    State    = $State
+                }
+                foreach ($propertyName in $cimPropertyValues.Keys) {
+                    $property = [Microsoft.Management.Infrastructure.CimProperty]::Create(
+                        $propertyName,
+                        $cimPropertyValues[$propertyName],
+                        [Microsoft.Management.Infrastructure.CimType]::String,
+                        [Microsoft.Management.Infrastructure.CimFlags]::Property
+                    )
+                    $instance.CimInstanceProperties.Add($property)
+                }
+                return $instance
+            }
+
             Mock -CommandName Get-ScheduledTaskInfo -MockWith {
                 param($TaskName, $TaskPath)
                 $mockInfo = [PSCustomObject]@{
@@ -228,36 +259,26 @@ InModuleScope -ModuleName 'ScheduledTasksManager' {
         }
 
         It 'Should accept pipeline input from Get-StmScheduledTask' {
-            $mockTask = [PSCustomObject]@{
-                TaskName     = 'PipelineTask'
-                TaskPath     = '\TestPath\'
-                State        = 'Ready'
-            }
-            $mockTask.PSObject.TypeNames.Insert(0, 'Microsoft.Management.Infrastructure.CimInstance#MSFT_ScheduledTask')
+            $mockTask = New-StmTestTaskCimInstance -TaskName 'PipelineTask'
 
             $result = $mockTask | Get-StmScheduledTaskInfo
 
             $result | Should -Not -BeNullOrEmpty
             $result.TaskName | Should -Be 'PipelineTask'
             Should -Invoke Get-ScheduledTaskInfo -Times 1 -Exactly
+            # The piped task must reach Get-ScheduledTaskInfo as -InputObject so its
+            # originating CIM session is reused, rather than being rebuilt by TaskName
+            # (which would fall back to the local Task Scheduler for a remote task).
+            Should -Invoke Get-ScheduledTaskInfo -Times 1 -ParameterFilter {
+                $null -ne $InputObject
+            }
         }
 
         It 'Should accept multiple tasks from pipeline' {
-            $mockTask1 = [PSCustomObject]@{
-                TaskName   = 'Task1'
-                TaskPath   = '\Path1\'
-                State      = 'Ready'
-            }
-            $mockTask1.PSObject.TypeNames.Insert(0, 'Microsoft.Management.Infrastructure.CimInstance#MSFT_ScheduledTask')
-
-            $mockTask2 = [PSCustomObject]@{
-                TaskName   = 'Task2'
-                TaskPath   = '\Path2\'
-                State      = 'Ready'
-            }
-            $mockTask2.PSObject.TypeNames.Insert(0, 'Microsoft.Management.Infrastructure.CimInstance#MSFT_ScheduledTask')
-
-            $mockTasks = @($mockTask1, $mockTask2)
+            $mockTasks = @(
+                New-StmTestTaskCimInstance -TaskName 'Task1' -TaskPath '\Path1\'
+                New-StmTestTaskCimInstance -TaskName 'Task2' -TaskPath '\Path2\'
+            )
 
             $result = $mockTasks | Get-StmScheduledTaskInfo
 
@@ -456,6 +477,25 @@ InModuleScope -ModuleName 'ScheduledTasksManager' {
             Should -Invoke Get-ScheduledTaskInfo -Times 1 -ParameterFilter {
                 -not $PSBoundParameters.ContainsKey('CimSession')
             }
+        }
+
+        It 'Should forward the supplied Credential to New-StmCimSession for a remote host' {
+            $credential = [System.Management.Automation.PSCredential]::new(
+                'TestUser',
+                (ConvertTo-SecureString 'TestPassword' -AsPlainText -Force)
+            )
+            $invokeParameters = @{
+                ComputerName = 'RemoteServer'
+                TaskName     = 'RemoteTask'
+                Credential   = $credential
+            }
+            Get-StmScheduledTaskInfo @invokeParameters | Out-Null
+
+            Should -Invoke New-StmCimSession -Times 1 -Exactly -ParameterFilter {
+                $Credential -eq $credential
+            }
+            # The remote session created for the lookup is torn down in the end block.
+            Should -Invoke Remove-CimSession -Times 1 -Exactly
         }
     }
 


### PR DESCRIPTION
## Summary
- `Get-StmScheduledTaskInfo -ComputerName <remote>` was calling `Get-ScheduledTaskInfo` without `-CimSession`, causing every task lookup to fall back to the local Task Scheduler and fail with HRESULT 0x80070002 ("file not found") for tasks that exist on the remote host.
- The wrapper error was then raised via `ThrowTerminatingError`, aborting the entire loop on the first failing task.

## Changes

**`Get-StmScheduledTaskInfo.ps1`** — four changes:
- Create a CIM session in `begin{}` when `ComputerName` is not the local host (and not `.` or `$env:COMPUTERNAME`)
- Pass `-CimSession` to `Get-ScheduledTaskInfo` when one is available
- Replace `ThrowTerminatingError` with `WriteError` + `continue` so per-task failures are non-terminating and the loop processes the remaining tasks
- Clean up the CIM session in `end{}`

## Behavior before vs after

```powershell
Get-StmScheduledTaskInfo -ComputerName <remote> -TaskName 'ServerInventory*' -Credential $cred
```

| | Before | After |
|---|---|---|
| Each task | `Get-ScheduledTaskInfo : The system cannot find the file specified.` (HRESULT 0x80070002) | Returns full task info |
| Loop behavior | Aborts on first failing task | Continues; failing tasks produce non-terminating errors |

## Test plan
- [x] `./build.ps1 UnitTest` — all 20 tests in `Get-StmScheduledTaskInfo.Tests.ps1` pass (3 new + 2 updated existing)
- [x] Lab-validated end-to-end on `STMDC01` (remote standalone Windows host): pristine module reproduced the exact user-reported failure; patched module returns all 3 tasks with full info, zero errors
- [x] Backtick line-continuation scan — none introduced

## Tests
**New (3):**
- `Get-StmScheduledTaskInfo.Remote-host CIM session plumbing (Issue 3 fix a).Should pass -CimSession to Get-ScheduledTaskInfo when ComputerName is a remote host`
- `Get-StmScheduledTaskInfo.Remote-host CIM session plumbing (Issue 3 fix a).Should NOT pass -CimSession to Get-ScheduledTaskInfo when ComputerName is localhost`
- `Get-StmScheduledTaskInfo.Loop continues on per-task failure (Issue 3 fix b).Should process remaining tasks (and write a per-task error) when one task fails`

**Updated (2):** the existing `Should throw terminating error...` and `Should include task name in error message` tests asserted the bug behavior. Updated to assert the new (correct) `WriteError` + `continue` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling: Task processing now continues when individual task operations fail instead of terminating the entire operation, with errors properly reported.

* **Improvements**
  * Enhanced support for querying scheduled tasks on remote computers with more reliable session management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tablackburn/ScheduledTasksManager/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->