### PR TITLE
chore(build): normalize PlatyPS-generated doc line endings to LF

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,13 @@ repos:
       - id: ggshield
         language_version: python3
         stages: [pre-commit]
+
+  # Safety net for line endings: the build's NormalizeDocsLineEndings task fixes
+  # PlatyPS-generated docs, but this catches CRLF from any other source (editors,
+  # ad-hoc tooling) before it reaches the index. .gitattributes already pins LF
+  # but only acts at git operations; this enforces it before the commit lands.
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: mixed-line-ending
+        args: [--fix=lf]

--- a/build.psake.ps1
+++ b/build.psake.ps1
@@ -74,7 +74,33 @@ $unitTestPreReqs = {
     return $result
 }
 
-Task -Name 'UnitTest' -Depends 'Build' -PreCondition $unitTestPreReqs -Description 'Execute Pester tests (excluding Integration)' {
+# Normalize PlatyPS-generated doc line endings to LF.
+# PlatyPS (invoked by PowerShellBuild's BUILDHELP task) writes files with CRLF
+# on Windows, which contradicts .gitattributes (`* text=auto eol=lf`) and
+# leaves docs/en-US/*.md as dirty in `git status` after every local build.
+# Inserting this between Build and the test tasks keeps the working tree clean
+# without depending on a pre-commit hook firing later.
+Task -Name 'NormalizeDocsLineEndings' -Depends 'Build' -Description 'Normalize generated doc files to LF (PlatyPS writes CRLF on Windows)' {
+    $docsPath = Join-Path -Path $PSScriptRoot -ChildPath 'docs'
+    if (-not (Test-Path -Path $docsPath)) {
+        return
+    }
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    $changed = 0
+    Get-ChildItem -Path $docsPath -Filter '*.md' -Recurse -File | ForEach-Object {
+        $original = [System.IO.File]::ReadAllText($_.FullName)
+        $normalized = $original -replace "`r`n", "`n"
+        if ($original -cne $normalized) {
+            [System.IO.File]::WriteAllText($_.FullName, $normalized, $utf8NoBom)
+            $changed++
+        }
+    }
+    if ($changed -gt 0) {
+        Write-Host "  Normalized $changed doc file(s) to LF" -ForegroundColor Gray
+    }
+}
+
+Task -Name 'UnitTest' -Depends 'NormalizeDocsLineEndings' -PreCondition $unitTestPreReqs -Description 'Execute Pester tests (excluding Integration)' {
     # Remove any previously imported project modules and import from the output dir
     $moduleManifest = Join-Path $PSBPreference.Build.ModuleOutDir "$($PSBPreference.General.ModuleName).psd1"
     Get-Module $PSBPreference.General.ModuleName | Remove-Module -Force -ErrorAction SilentlyContinue
@@ -125,7 +151,7 @@ $scriptAnalysisPreReqs = {
     return $result
 }
 
-Task -Name 'ScriptAnalysis' -Depends 'Build' -PreCondition $scriptAnalysisPreReqs -Description 'Execute PSScriptAnalyzer' {
+Task -Name 'ScriptAnalysis' -Depends 'NormalizeDocsLineEndings' -PreCondition $scriptAnalysisPreReqs -Description 'Execute PSScriptAnalyzer' {
     # Get only .ps1 files (exclude .psd1 module manifests which are auto-generated)
     $ps1Files = Get-ChildItem -Path $PSBPreference.Build.ModuleOutDir -Filter '*.ps1' -Recurse
 

--- a/build.psake.ps1
+++ b/build.psake.ps1
@@ -82,7 +82,7 @@ $unitTestPreReqs = {
 # without depending on a pre-commit hook firing later.
 Task -Name 'NormalizeDocsLineEndings' -Depends 'Build' -Description 'Normalize generated doc files to LF (PlatyPS writes CRLF on Windows)' {
     $docsPath = Join-Path -Path $PSScriptRoot -ChildPath 'docs'
-    if (-not (Test-Path -Path $docsPath)) {
+    if (-not (Test-Path $docsPath)) {
         return
     }
     $utf8NoBom = [System.Text.UTF8Encoding]::new($false)


### PR DESCRIPTION
## Summary

PowerShellBuild's `BUILDHELP` task invokes PlatyPS, which writes `docs/en-US/*.md` with CRLF on Windows. That contradicts the repo's `.gitattributes` (`* text=auto eol=lf`, pinned in #34) and dirties `git status` after every local build with 28 phantom "modifications" — line-ending only, zero content change.

This PR adds two-layer prevention.

## Changes

### Layer 1 — build-time fix (`build.psake.ps1`)
New `NormalizeDocsLineEndings` psake task that runs after `Build`:
- Walks `docs/**/*.md`, rewrites any CRLF to LF using UTF-8 without BOM.
- Only writes files that actually changed (avoids touching mtimes unnecessarily).
- `UnitTest` and `ScriptAnalysis` now depend on `NormalizeDocsLineEndings` instead of `Build` directly, so it always runs in the standard chain.

### Layer 2 — pre-commit safety net (`.pre-commit-config.yaml`)
Adds `mixed-line-ending --fix=lf` from `pre-commit/pre-commit-hooks`:
- Catches CRLF from any other source — editors, ad-hoc tooling, future tasks — before it reaches the index.
- `.gitattributes` alone only acts at git operations and can't stop a tool from writing CRLF into the working tree between operations. This is the safety net.

## Verification

**Layer 1 — local `./build.ps1 UnitTest` run:**
```
Task: BUILDHELP
Task: NORMALIZEDOCSLINEENDINGS
  Normalized 28 doc file(s) to LF
Task: UNITTEST
...
Tests Passed: 1423, Failed: 0, Skipped: 4
```
Post-build check: 28 files LF-only, 0 with CRLF, `git status docs/` clean.

**Layer 2 — verified live on this PR's commit:**
The pre-commit hook ran during the commit itself:
```
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
mixed line ending........................................................Passed
```

## Test plan
- [x] `./build.ps1 -Task UnitTest` — 1423 pass, 0 fail, NormalizeDocsLineEndings reports `Normalized 28 doc file(s) to LF`
- [x] `git status` clean after build (no phantom doc modifications)
- [x] Pre-commit hook runs and passes on commit
- [ ] CI: PSScriptAnalyzer + Unit Tests pass
- [ ] CI: `pre-commit.ci` confirms `mixed-line-ending` hook is valid

## Notes
- Surfaced as a side-effect of debugging #42 — every `./build.ps1` run during that work re-dirtied 28 docs in `git status`.
- The integration test failure that triggered this discovery is fixed in #42 (separate root cause); this PR is purely about preventing the recurring git-status noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured pre-commit hooks to automatically enforce consistent line endings across the repository.
  * Added automated line ending normalization for documentation to the build system, running before unit tests and script analysis to ensure consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tablackburn/ScheduledTasksManager/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->