### PR TITLE
chore(release): bump module version to 0.11.4 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.11.4] - 2026-05-20
+
+### Fixed
+
+- `Get-StmScheduledTaskInfo`: Now targets the remote Task Scheduler through a CIM session when `-ComputerName` is a remote host, instead of falling back to the local machine and failing with HRESULT `0x80070002` ("the system cannot find the file specified") for tasks that exist only on the remote host. Tasks piped in (for example from `Get-StmScheduledTask -ComputerName <remote>`) reuse their originating CIM session as well.
+- `Get-StmScheduledTaskInfo`: A failure retrieving info for one task is now a non-terminating error, so the remaining tasks are still processed instead of the first failure aborting the entire call.
+- `Get-StmClusteredScheduledTask`: When `-TaskName` is specified and the task is not found, writes a structured `ClusteredScheduledTaskNotFound` error instead of silently returning a name-only partial result and a misleading warning. Bulk queries (no `-TaskName`) keep the existing warning.
+- `Get-StmClusteredScheduledTask`: When the cluster reports an owner node but that node does not return the named task, writes a structured `ClusteredScheduledTaskOwnerLookupFailed` error instead of leaking the raw `CmdletizationQuery_NotFound_TaskName` error.
+- `Get-StmClusteredScheduledTaskInfo`: When `-TaskName` is specified but cannot be resolved, writes a structured `ClusteredScheduledTaskNotResolvable` error instead of a warning. Bulk queries keep the existing warning.
+- `Disable-StmClusteredScheduledTask`: Post-unregister verification no longer misreports a successful unregister as a failure now that a missing task surfaces as a structured error.
+
 ## [0.11.3] - 2026-02-06
 
 ### Changed

--- a/ScheduledTasksManager/ScheduledTasksManager.psd1
+++ b/ScheduledTasksManager/ScheduledTasksManager.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'ScheduledTasksManager.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.11.3'
+    ModuleVersion        = '0.11.4'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Desktop', 'Core')


### PR DESCRIPTION
## Summary

Cuts the **0.11.4** release that rolls up the bug fixes in #42 and #43.

- `ScheduledTasksManager.psd1`: `ModuleVersion` `0.11.3` → `0.11.4`. Two bug fixes, no API surface changes → **patch** bump per SemVer.
- `CHANGELOG.md`: new `## [0.11.4]` section under `### Fixed`.

This PR touches **only** the manifest version and the changelog — no code paths change.

## ⚠️ Merge order

This PR must merge **last**, after the changes it documents:

- [ ] #45 — `chore(build): normalize PlatyPS doc line endings`
- [ ] #43 — `fix(scheduledtaskinfo): remote CIM session + continue loop`
- [ ] #42 — `fix(cluster): surface named-task lookup failures as errors`
- [ ] **then this PR**

There are no file conflicts (none of the three feature branches touch `CHANGELOG.md` or the manifest), but the changelog text describes behavior that only lands once #42 and #43 are merged, so this should go in afterward.

## Changelog entries

```
## [0.11.4] - 2026-05-20

### Fixed

- Get-StmScheduledTaskInfo: remote Task Scheduler via CIM session for -ComputerName
  (no more local 0x80070002 fallback); piped tasks reuse their originating session.
- Get-StmScheduledTaskInfo: per-task failures are non-terminating (loop continues).
- Get-StmClusteredScheduledTask: structured ClusteredScheduledTaskNotFound on named miss.
- Get-StmClusteredScheduledTask: structured ClusteredScheduledTaskOwnerLookupFailed
  instead of leaking the raw cmdletization error.
- Get-StmClusteredScheduledTaskInfo: structured ClusteredScheduledTaskNotResolvable on
  unresolvable named lookup.
- Disable-StmClusteredScheduledTask: post-unregister verification no longer misreports
  success as failure under the new error contract.
```

## Notes

- #45 is build/dev tooling (doc line-ending normalization) with no consumer-facing impact, so it is intentionally **not** in the changelog. Say the word if you'd prefer it listed.
- `ReleaseNotes` in the manifest is a static link to `CHANGELOG.md`, so no change needed there.

## Test plan
- [x] `Import-PowerShellDataFile` parses the manifest; `ModuleVersion` reads `0.11.4`
- [ ] CI: PSScriptAnalyzer + Unit Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and reporting for scheduled task operations
  * Fixed remote connection handling for task information retrieval
  * Improved task lookup and resolution error messages
  * Corrected task management verification behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tablackburn/ScheduledTasksManager/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->