### PR TITLE
chore(release): add #26 to 0.11.4 changelog; build release notes from CHANGELOG

### DIFF
--- a/.github/workflows/PublishModuleToPowerShellGallery.yaml
+++ b/.github/workflows/PublishModuleToPowerShellGallery.yaml
@@ -81,8 +81,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          $version = '${{ steps.version.outputs.version }}'
+          $version = $env:VERSION
 
           # Build release notes from this version's CHANGELOG.md section so the release
           # body carries only the curated, user-facing entries (not the full PR list that

--- a/.github/workflows/PublishModuleToPowerShellGallery.yaml
+++ b/.github/workflows/PublishModuleToPowerShellGallery.yaml
@@ -80,7 +80,7 @@ jobs:
         if: steps.check_release.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
+          REPOSITORY: ${{ github.repository }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           $version = $env:VERSION
@@ -111,7 +111,7 @@ jobs:
               # previous release.
               $previousTag = git tag --list 'v*' --sort=-version:refname | Select-Object -First 1
               if ($previousTag) {
-                  $body += "`n`n**Full Changelog**: https://github.com/$env:REPO/compare/$previousTag...v$version"
+                  $body += "`n`n**Full Changelog**: https://github.com/${env:REPOSITORY}/compare/$previousTag...v$version"
               }
               Set-Content -LiteralPath './release-notes.md' -Value $body -Encoding utf8
               gh release create "v$version" --title "v$version" --notes-file './release-notes.md'

--- a/.github/workflows/PublishModuleToPowerShellGallery.yaml
+++ b/.github/workflows/PublishModuleToPowerShellGallery.yaml
@@ -78,10 +78,40 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.check_release.outputs.exists == 'false'
-        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          gh release create "v${{ steps.version.outputs.version }}" \
-            --title "v${{ steps.version.outputs.version }}" \
-            --generate-notes
+          $version = '${{ steps.version.outputs.version }}'
+
+          # Build release notes from this version's CHANGELOG.md section so the release
+          # body carries only the curated, user-facing entries (not the full PR list that
+          # --generate-notes produces, which is dominated by bot/CI/chore PRs).
+          $headerPattern = '^##\s+\[' + [regex]::Escape($version) + '\]'
+          $capturing = $false
+          $captured = [System.Collections.Generic.List[string]]::new()
+          foreach ($line in (Get-Content -LiteralPath './CHANGELOG.md')) {
+              if (-not $capturing) {
+                  if ($line -match $headerPattern) { $capturing = $true }
+                  continue
+              }
+              if ($line -match '^##\s+\[') { break }   # next version header ends the section
+              $captured.Add($line)
+          }
+          $body = ($captured -join "`n").Trim()
+
+          if ([string]::IsNullOrWhiteSpace($body)) {
+              Write-Host "::warning::No CHANGELOG.md section found for $version; falling back to auto-generated notes."
+              gh release create "v$version" --title "v$version" --generate-notes
+          }
+          else {
+              # Append a compare link against the most recent existing tag. The v$version
+              # tag does not exist yet (this step creates it), so the latest tag is the
+              # previous release.
+              $previousTag = git tag --list 'v*' --sort=-version:refname | Select-Object -First 1
+              if ($previousTag) {
+                  $body += "`n`n**Full Changelog**: https://github.com/$env:REPO/compare/$previousTag...v$version"
+              }
+              Set-Content -LiteralPath './release-notes.md' -Value $body -Encoding utf8
+              gh release create "v$version" --title "v$version" --notes-file './release-notes.md'
+          }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Running cmdlets with `-WhatIf` no longer fails with null CIM session errors. The caller's `$WhatIfPreference` was propagating through PowerShell's dynamic scope into the internal `New-StmCimSession` helper, causing `New-CimSession` to return nothing — which broke 14 of the 16 cmdlets that connect over a CIM session whenever `-WhatIf` was used.
 - `Get-StmScheduledTaskInfo`: Now targets the remote Task Scheduler through a CIM session when `-ComputerName` is a remote host, instead of falling back to the local machine and failing with HRESULT `0x80070002` ("the system cannot find the file specified") for tasks that exist only on the remote host. Tasks piped in (for example from `Get-StmScheduledTask -ComputerName <remote>`) reuse their originating CIM session as well.
 - `Get-StmScheduledTaskInfo`: A failure retrieving info for one task is now a non-terminating error, so the remaining tasks are still processed instead of the first failure aborting the entire call.
 - `Get-StmClusteredScheduledTask`: When `-TaskName` is specified and the task is not found, writes a structured `ClusteredScheduledTaskNotFound` error instead of silently returning a name-only partial result and a misleading warning. Bulk queries (no `-TaskName`) keep the existing warning.


### PR DESCRIPTION
## Summary

Two related changes so release notes carry only **user-facing** changes and stay consistent with `CHANGELOG.md`.

### 1. `CHANGELOG.md` — add the missing #26 entry to `0.11.4`
PR #26 (*Prevent WhatIf preference propagation in New-StmCimSession*) shipped in `0.11.4` but had no curated changelog line. It merged **2026-03-02**, ~2.5 months before the release was cut, so it got swept into `0.11.4` without its own entry. It's a real user-facing fix — before it, `-WhatIf` failed with null CIM session errors across **14 of 16** cmdlets — so it belongs in the notes.

### 2. Publish workflow — source release notes from `CHANGELOG.md`
The `Create GitHub Release` step previously used `gh release create --generate-notes`, which lists **every merged PR since the last release tag**. Because a release is only cut on a manifest version bump, long stretches accumulate bot/CI/chore PRs that then flood the notes (v0.11.4 swept up 20 PRs, ~16 of them dependabot/pre-commit.ci/CI). The step now extracts the current version's section from `CHANGELOG.md` and passes it via `--notes-file`, so release notes = the curated, user-facing changelog. Includes a `Full Changelog` compare link, and **falls back to `--generate-notes`** if a version has no changelog section (so a release is never blocked).

## Why this is safe
- **No manifest change** → does **not** trigger the publish workflow / a re-publish.
- `0.11.4` is already published; its GitHub release notes were corrected manually. This change applies to **future** releases (0.11.5+).

## Verification
- [x] Extraction logic tested locally against the updated `CHANGELOG.md`: returns the full `0.11.4` section (7 bullets incl. the new #26 line), starts at `### Fixed`, stops before `0.11.3`.
- [x] Workflow YAML parses; the rewritten step inherits the job's `pwsh` shell (no `shell:` key).
- [ ] CI: PSScriptAnalyzer + Unit Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cmdlets failing with null CIM session errors when using the `-WhatIf` parameter. Users can now safely use `-WhatIf` with all CIM-session-based cmdlets without encountering initialization failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tablackburn/ScheduledTasksManager/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->