### PR TITLE
ci(release): populate PSData.ReleaseNotes from CHANGELOG at publish time

### DIFF
--- a/build.depend.psd1
+++ b/build.depend.psd1
@@ -25,6 +25,11 @@
     'PSScriptAnalyzer' = @{
         Version = '1.24.0'
     }
+    # Parses CHANGELOG.md (Keep a Changelog format) so the Publish task can populate the
+    # built manifest's PSData.ReleaseNotes from the matching version's entry.
+    'ChangelogManagement' = @{
+        Version = '3.1.0'
+    }
 
     # Optional: Integration tests only
     # AutomatedLab is required for running integration tests against a real failover cluster

--- a/build.psake.ps1
+++ b/build.psake.ps1
@@ -183,8 +183,47 @@ Task -Name 'ScriptAnalysis' -Depends 'NormalizeDocsLineEndings' -PreCondition $s
     }
 }
 
+# Populate the built manifest's ReleaseNotes from the matching CHANGELOG.md entry so the
+# PowerShell Gallery release-notes panel shows the curated, user-facing notes (the same
+# content used for the GitHub release) instead of just a link to the changelog. Depends on
+# Build so the staged manifest in ModuleOutDir exists; runs before Publish (see
+# $PSBPublishDependency below). Non-fatal if the changelog can't be read or has no entry
+# for the version being published, so a release is never blocked.
+Task -Name 'UpdateReleaseNotes' -Depends 'Build' -Description 'Set built manifest ReleaseNotes from the matching CHANGELOG.md entry' {
+    $changelogPath = Join-Path -Path $PSScriptRoot -ChildPath 'CHANGELOG.md'
+    if (-not (Test-Path -Path $changelogPath)) {
+        Write-Warning 'CHANGELOG.md not found; leaving ReleaseNotes unchanged.'
+        return
+    }
+
+    $moduleVersion = $PSBPreference.General.ModuleVersion
+    try {
+        Import-Module -Name 'ChangelogManagement' -ErrorAction Stop
+        $changelogData = Get-ChangelogData -Path $changelogPath -ErrorAction Stop
+    }
+    catch {
+        Write-Warning "Could not read CHANGELOG.md ($($_.Exception.Message)); leaving ReleaseNotes unchanged."
+        return
+    }
+
+    $releaseEntry = $changelogData.Released |
+        Where-Object { [string]$_.Version -eq [string]$moduleVersion } |
+        Select-Object -First 1
+    if (-not $releaseEntry) {
+        Write-Warning "No CHANGELOG.md entry found for version $moduleVersion; leaving ReleaseNotes unchanged."
+        return
+    }
+
+    $releaseNotes = $releaseEntry.RawData.Trim()
+    $builtManifest = Join-Path -Path $PSBPreference.Build.ModuleOutDir -ChildPath "$($PSBPreference.General.ModuleName).psd1"
+    Update-ModuleManifest -Path $builtManifest -ReleaseNotes $releaseNotes -ErrorAction Stop
+    Write-Host "  Set ReleaseNotes on built manifest from CHANGELOG [$($releaseEntry.Version)] ($($releaseNotes.Length) chars)" -ForegroundColor Gray
+}
+
 # Use UnitTest and custom ScriptAnalysis instead of PowerShellBuild's built-in tasks
 $PSBTestDependency = @('Init_Integration', 'UnitTest', 'ScriptAnalysis')
+# Inject ReleaseNotes into the built manifest before publishing (default is just 'Test').
+$PSBPublishDependency = @('Test', 'UpdateReleaseNotes')
 Task -Name 'Test' -FromModule 'PowerShellBuild' -MinimumVersion '0.7.3'
 
 # Integration tests require AutomatedLab and a Hyper-V host


### PR DESCRIPTION
## Summary

Auto-populates the module manifest's `PSData.ReleaseNotes` from `CHANGELOG.md` at publish time, so the **PowerShell Gallery** release-notes panel shows the curated, user-facing notes for each version — instead of today's static link to `CHANGELOG.md`. This makes the Gallery match the **GitHub release** body (which #47 already builds from the same CHANGELOG section).

This is the follow-up from researching how other PowerShell projects handle release notes — it mirrors the **DSC Community `Sampler`** pattern (`ChangelogManagement` → manifest `ReleaseNotes`), which is the de-facto standard.

## Changes

- **`build.depend.psd1`** — add [`ChangelogManagement`](https://github.com/natescherer/ChangelogManagement) `3.1.0`, the standard Keep-a-Changelog parser (same dependency model as Pester/PowerShellBuild/PSScriptAnalyzer).
- **`build.psake.ps1`** — new `UpdateReleaseNotes` task (`-Depends 'Build'`) that:
  - reads the `CHANGELOG.md` entry matching `$PSBPreference.General.ModuleVersion` via `Get-ChangelogData`,
  - sets the **built** manifest's `PrivateData.PSData.ReleaseNotes` via `Update-ModuleManifest`,
  - is wired into `$PSBPublishDependency = @('Test', 'UpdateReleaseNotes')` so it runs **before** `Publish-PSBuildModule` (same extension mechanism the repo already uses for `$PSBTestDependency`).
  - **Non-fatal**: if the changelog can't be read or has no entry for the version being published, it warns and leaves `ReleaseNotes` unchanged — a release is never blocked.

No workflow change needed: the publish step already runs `./build.ps1 -Task 'Publish' -Bootstrap`, and `Publish` now depends on the new task. The GitHub-release notes (#47) and the Gallery `ReleaseNotes` now both derive from the same `CHANGELOG.md` section.

## Why not unify the GitHub-release extraction too?
The workflow's `Create GitHub Release` step runs without bootstrapping modules, so `ChangelogManagement` isn't available there; its small in-repo extractor (#47) needs no dependency. Keeping them separate avoids installing a module just to read a file in that step. Both still source the same CHANGELOG section.

## Verification (local)
- `ChangelogManagement` parses this repo's `CHANGELOG.md` cleanly (26 versions).
- `./build.ps1 -Task UpdateReleaseNotes` → built `0.11.4` manifest's `ReleaseNotes` becomes the curated `0.11.4` section (1,975 chars, includes `### Fixed`); manifest stays valid (version + `RequiredModules` intact).
- `Update-ModuleManifest -ReleaseNotes` round-trips the multi-line content (backticks, `$`, em-dash, apostrophes) correctly.

## Stacking / merge order
Based on `chore/release-notes-from-changelog` (**#47**) since it builds on that workflow change; GitHub will auto-retarget this to `main` when #47 merges. **Merge #47 first, then this.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)