### PR TITLE
ci(release): make UpdateReleaseNotes manifest write non-fatal

### DIFF
--- a/build.psake.ps1
+++ b/build.psake.ps1
@@ -220,8 +220,19 @@ Task -Name 'UpdateReleaseNotes' -Depends 'Build' -Description 'Set built manifes
         return
     }
     $builtManifest = Join-Path -Path $PSBPreference.Build.ModuleOutDir -ChildPath "$($PSBPreference.General.ModuleName).psd1"
-    Update-ModuleManifest -Path $builtManifest -ReleaseNotes $releaseNotes -ErrorAction Stop
-    Write-Host "  Set ReleaseNotes on built manifest from CHANGELOG [$($releaseEntry.Version)] ($($releaseNotes.Length) chars)" -ForegroundColor Gray
+    if (-not (Test-Path -Path $builtManifest)) {
+        Write-Warning "Built manifest not found at '$builtManifest'; leaving ReleaseNotes unchanged."
+        return
+    }
+    try {
+        Update-ModuleManifest -Path $builtManifest -ReleaseNotes $releaseNotes -ErrorAction Stop
+        Write-Host "  Set ReleaseNotes on built manifest from CHANGELOG [$($releaseEntry.Version)] ($($releaseNotes.Length) chars)" -ForegroundColor Gray
+    }
+    catch {
+        # Keep publishing unblocked: a failure here just leaves the manifest's existing
+        # ReleaseNotes in place rather than aborting the release.
+        Write-Warning "Failed to set ReleaseNotes on the built manifest ($($_.Exception.Message)); leaving it unchanged."
+    }
 }
 
 # Use UnitTest and custom ScriptAnalysis instead of PowerShellBuild's built-in tasks

--- a/build.psake.ps1
+++ b/build.psake.ps1
@@ -231,7 +231,7 @@ Task -Name 'UpdateReleaseNotes' -Depends 'Build' -Description 'Set built manifes
     catch {
         # Keep publishing unblocked: a failure here just leaves the manifest's existing
         # ReleaseNotes in place rather than aborting the release.
-        Write-Warning "Failed to set ReleaseNotes on the built manifest ($($_.Exception.Message)); leaving it unchanged."
+        Write-Warning "Failed to set ReleaseNotes on the built manifest '$builtManifest' ($($_.Exception.Message)); leaving it unchanged."
     }
 }
 


### PR DESCRIPTION
## Summary

Backports a robustness guard surfaced during the consumer rollout (PlexAutomationToolkit#56 review). The `UpdateReleaseNotes` task (added in #49, hardened in #50) is documented as non-fatal, but the final `Update-ModuleManifest -ErrorAction Stop` was **unguarded** — a failure there (e.g. a missing built manifest) would hard-fail `Publish`, contradicting the design.

Now: `Test-Path` the built manifest, and wrap `Update-ModuleManifest` in try/catch that warns and leaves the existing `ReleaseNotes` in place. Non-fatal at every step, so a release is never blocked.

Brings STM level with `PowerShellModuleTemplate` and the consumer modules, which now all include this guard.

`build.psake.ps1` parses OK. No manifest change → does not trigger a re-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)