### PR TITLE
ci(release): allow PSGallery publish to recover when the GitHub release already exists

### DIFF
--- a/.github/workflows/PublishModuleToPowerShellGallery.yaml
+++ b/.github/workflows/PublishModuleToPowerShellGallery.yaml
@@ -46,12 +46,15 @@ jobs:
           fi
 
       - name: Bootstrap
-        if: steps.check_release.outputs.exists == 'false'
+        # Runs unconditionally: the PSGallery check below depends on it
+        # (BuildHelpers/Set-BuildEnvironment) and now runs regardless of the release
+        # check, so a release created but never published can still be recovered.
         run: ./build.ps1 -Task 'Init' -Bootstrap
 
       - name: Check if Version Exists in PSGallery
         id: check_psgallery
-        if: steps.check_release.outputs.exists == 'false'
+        # Runs unconditionally so a release that was created but never published can
+        # still be recovered (see Publish gating below).
         run: |
           Import-Module BuildHelpers
           Set-BuildEnvironment -Force
@@ -72,7 +75,7 @@ jobs:
           Add-Content -LiteralPath $env:GITHUB_OUTPUT -Value "IN_GALLERY=$inGallery" -Confirm:$False -Encoding 'UTF8'
 
       - name: Publish to PSGallery
-        if: steps.check_release.outputs.exists == 'false' && steps.check_psgallery.outputs.IN_GALLERY == 'False'
+        if: steps.check_psgallery.outputs.IN_GALLERY == 'False'
         env:
           PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
         run: ./build.ps1 -Task 'Publish' -Bootstrap


### PR DESCRIPTION
Propagates **PowerShellModuleTemplate#33**, adapted for this repo's structure.

Publishing was gated on `check_release.outputs.exists == 'false'`, so once a GitHub release exists publishing is permanently skipped — a release-created-but-publish-failed run can't recover.

STM is a special case: `check_psgallery` uses BuildHelpers and depends on `Bootstrap` (so it runs *after* it), and `Publish` self-bootstraps. So the regate here:
- **Bootstrap** + **Check if Version Exists in PSGallery** now run **unconditionally** (the PSGallery check needs Bootstrap, and must run regardless of the release check).
- **Publish to PSGallery** gated **only** on `check_psgallery.outputs.IN_GALLERY == 'False'` (was also gated on the release check).
- **Create GitHub Release** unchanged.

Recovery path: release exists + not on gallery → check runs → `IN_GALLERY=False` → Publish runs → Create Release skipped. Flagged by CodeRabbit + Copilot during the YTMP rollout. YAML parses; no manifest change (no republish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)