### PR TITLE
ci(release): align STM's PSGallery check with the fleet (self-contained, hardened)

### DIFF
--- a/.github/workflows/PublishModuleToPowerShellGallery.yaml
+++ b/.github/workflows/PublishModuleToPowerShellGallery.yaml
@@ -45,47 +45,32 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Bootstrap
-        # Runs unconditionally: the PSGallery check below depends on it
-        # (BuildHelpers/Set-BuildEnvironment) and now runs regardless of the release
-        # check, so a release created but never published can still be recovered.
-        run: ./build.ps1 -Task 'Init' -Bootstrap
-
       - name: Check if Version Exists in PSGallery
         id: check_psgallery
         # Runs unconditionally so a release that was created but never published can
         # still be recovered (see Publish gating below).
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          Import-Module BuildHelpers
-          Set-BuildEnvironment -Force
-          [version]$githubVersion = Get-Metadata -Path $env:BHPSModuleManifest -PropertyName 'ModuleVersion' -ErrorAction 'Stop'
+          $version = $env:VERSION
           $findError = $null
-          $moduleSplat = @{
-              Repository      = 'PSGallery'
-              Name            = $env:BHProjectName
-              RequiredVersion = $githubVersion
-              AllowPrerelease = $True
-              ErrorAction     = 'SilentlyContinue'
-              ErrorVariable   = 'findError'
-          }
-          $published = Find-Module @moduleSplat
+          $published = Find-Module -Name ScheduledTasksManager -RequiredVersion $version -Repository PSGallery -ErrorAction SilentlyContinue -ErrorVariable findError
           if ($published) {
-              $inGallery = $True
+            Write-Host "PSGallery version $version already exists"
+            "exists=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          } elseif ($findError) {
+            # Find-Module records no error when the version simply isn't on the gallery,
+            # so a recorded error means the query itself failed (transient/network). Don't
+            # treat that as "not published" (publishing is gated only on this check) — fail
+            # so the run is visibly retryable instead of attempting a blind publish.
+            throw "PowerShell Gallery query failed for version ${version}: $($findError[0].Exception.Message)"
+          } else {
+            Write-Host "PSGallery version $version not found - will publish"
+            "exists=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           }
-          elseif ($findError) {
-              # Find-Module records no error when the version simply isn't on the gallery,
-              # so a recorded error means the query itself failed (transient/network). Don't
-              # treat that as "not published" (publishing is gated only on this check) — fail
-              # so the run is visibly retryable instead of attempting a blind publish.
-              throw "PowerShell Gallery query failed for version ${githubVersion}: $($findError[0].Exception.Message)"
-          }
-          else {
-              $inGallery = $False
-          }
-          Add-Content -LiteralPath $env:GITHUB_OUTPUT -Value "IN_GALLERY=$inGallery" -Confirm:$False -Encoding 'UTF8'
 
       - name: Publish to PSGallery
-        if: steps.check_psgallery.outputs.IN_GALLERY == 'False'
+        if: steps.check_psgallery.outputs.exists == 'false'
         env:
           PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
         run: ./build.ps1 -Task 'Publish' -Bootstrap

--- a/.github/workflows/PublishModuleToPowerShellGallery.yaml
+++ b/.github/workflows/PublishModuleToPowerShellGallery.yaml
@@ -59,15 +59,25 @@ jobs:
           Import-Module BuildHelpers
           Set-BuildEnvironment -Force
           [version]$githubVersion = Get-Metadata -Path $env:BHPSModuleManifest -PropertyName 'ModuleVersion' -ErrorAction 'Stop'
+          $findError = $null
           $moduleSplat = @{
               Repository      = 'PSGallery'
               Name            = $env:BHProjectName
               RequiredVersion = $githubVersion
               AllowPrerelease = $True
               ErrorAction     = 'SilentlyContinue'
+              ErrorVariable   = 'findError'
           }
-          if (Find-Module @moduleSplat) {
+          $published = Find-Module @moduleSplat
+          if ($published) {
               $inGallery = $True
+          }
+          elseif ($findError) {
+              # Find-Module records no error when the version simply isn't on the gallery,
+              # so a recorded error means the query itself failed (transient/network). Don't
+              # treat that as "not published" (publishing is gated only on this check) — fail
+              # so the run is visibly retryable instead of attempting a blind publish.
+              throw "PowerShell Gallery query failed for version ${githubVersion}: $($findError[0].Exception.Message)"
           }
           else {
               $inGallery = $False


### PR DESCRIPTION
Supersedes the BuildHelpers-adapted hardening on this branch. With prereleases not planned (confirmed), STM's BuildHelpers-based PSGallery check has no remaining upside over the fleet's self-contained one — and it's been the source of STM's recurring divergence (it forced the Bootstrap-before-check ordering, the unconditional-Bootstrap recovery-gap workaround, and a bespoke `IN_GALLERY` hardening on every template change).

## Changes
- **`check_psgallery`** → fleet's self-contained, hardened `Find-Module -Name ScheduledTasksManager -RequiredVersion $env:VERSION ... -ErrorVariable findError` (reuses the existing `version` step instead of re-deriving via `Get-Metadata`). Outputs `exists`. Keeps the hardening: publish only on a clean miss; `throw` on a query error rather than treating it as not-published.
- **Publish gate** → `steps.check_psgallery.outputs.exists == 'false'` (was `IN_GALLERY == 'False'`).
- **Removed the now-dead `Bootstrap` step**: the self-contained check needs no BuildHelpers, and `Publish` self-bootstraps + builds (`$PSBPublishDependency` → `UpdateReleaseNotes` → `Build`), so nothing else consumed it. This also retires the recovery-gap unconditional-Bootstrap workaround.

Net: STM's PSGallery-check logic is now identical to the fleet's, so future template changes propagate cleanly. The **`windows-latest` runner stays** (legitimate — Windows-only `ScheduledTasks` dependency). YAML parses (6 steps); no manifest change (no republish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module publishing workflow to enhance version existence checking with improved error handling for transient issues, ensuring more reliable publication operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tablackburn/ScheduledTasksManager/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->