### PR TITLE
fix(tests): run the param-help check (populate vars in BeforeDiscovery)

### DIFF
--- a/tests/Help.tests.ps1
+++ b/tests/Help.tests.ps1
@@ -129,11 +129,16 @@ BeforeAll {
 Describe "Test help for <_.Name>" -ForEach $commands {
 
     BeforeDiscovery {
-        # Get command help, parameters, and links
+        # Get command help, parameters, and links. These are duplicated in BeforeAll
+        # below; they must also exist here because the nested Context blocks use them in
+        # -ForEach, which Pester evaluates during discovery (before BeforeAll runs).
         $command               = $_
+        $commandName           = $command.Name
         $commandHelp           = Get-Help -Name $command.Name -ErrorAction 'SilentlyContinue'
         $commandParameters     = global:FilterOutCommonParameters -Parameters $command.ParameterSets.Parameters
         $commandParameterNames = $commandParameters.Name
+        $helpParameters        = global:FilterOutCommonParameters -Parameters $commandHelp.Parameters.Parameter
+        $helpParameterNames    = $helpParameters.Name
         $helpLinks             = $commandHelp.relatedLinks.navigationLink.uri | Where-Object { $_ -match '^https?://' }
     }
 


### PR DESCRIPTION
Propagates **PowerShellModuleTemplate#35** (canonical fix, merged).

The `Help.tests.ps1` 'help parameter help' Context used `-Foreach $helpParameterNames` with the variable set only in `BeforeAll`. Since Pester evaluates `-Foreach` at **discovery**, the collection was `$null` then and the Context expanded to **zero tests** — the 'no stale/extra parameters documented in help' check was a silent no-op. Fix: populate `$helpParameters`/`$helpParameterNames` (and `$commandName`, used in the Context name) in `BeforeDiscovery`.

Verified on the template (#35) with Pester 5.7.1 (3 tests vs 0). Identical block across the fleet, applied per-repo. No source/manifest change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced help testing infrastructure to ensure critical test variables are properly initialized during discovery time, improving test reliability and execution consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tablackburn/ScheduledTasksManager/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->