### PR TITLE
fix(tests): use $commandParameterNames in the param-help assertion

### DIFF
--- a/tests/Help.tests.ps1
+++ b/tests/Help.tests.ps1
@@ -217,7 +217,7 @@ Describe "Test help for <_.Name>" -ForEach $commands {
 
         # Shouldn't find extra parameters in help
         It 'finds help parameter in code: <_>' {
-            $_ -in $parameterNames | Should -Be $true
+            $_ -in $commandParameterNames | Should -Be $true
         }
     }
 }


### PR DESCRIPTION
One-line follow-up to #54. STM's param-help Context asserted against `$parameterNames` (never defined; only `$commandParameterNames` exists) — drift from the canonical scaffolding. #54's discovery-phase fix activates that Context, so this corrects the variable to match the rest of the fleet (Srr/ReScene/Plex got the same fix in their discovery PRs).

Latent today (the Context still generates 0 tests in CI until `Get-Help` returns parameters at discovery — tracked for the test-unification effort), but removes the inconsistency. No source/manifest change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved help parameter validation tests to ensure consistency between help documentation and command implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tablackburn/ScheduledTasksManager/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->