### PR TITLE
chore(integration): replace sample lab admin password with a placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Changed
-
-- Integration test setup no longer ships a sample admin password. `integration-test-config.example.json` and `tests/Integration/README.md` now use an explicit placeholder you replace with your own strong password (the real `integration-test-config.json` is gitignored and never committed).
-
 ## [0.11.4] - 2026-05-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Integration test setup no longer ships a sample admin password. `integration-test-config.example.json` and `tests/Integration/README.md` now use an explicit placeholder you replace with your own strong password (the real `integration-test-config.json` is gitignored and never committed).
+
 ## [0.11.4] - 2026-05-20
 
 ### Fixed

--- a/integration-test-config.example.json
+++ b/integration-test-config.example.json
@@ -5,7 +5,8 @@
     "name": "StmTestLab",
     "domainName": "stmtest.local",
     "adminUser": "Install",
-    "adminPassword": "P@ssw0rd1",
+    "_password_comment": "Replace with your own strong password meeting Windows complexity rules (12+ chars with upper, lower, digit, and symbol). Your real integration-test-config.json is gitignored and is never committed.",
+    "adminPassword": "<choose-a-strong-password>",
     "_mode_comment": "Set to 'local' for AutomatedLab on this machine, 'remote' for AutomatedLab on another server",
     "mode": "local"
   },

--- a/tests/Integration/README.md
+++ b/tests/Integration/README.md
@@ -78,7 +78,7 @@ Invoke-Pester .\ClusteredScheduledTask.Integration.Tests.ps1 -Output Detailed
 
 **Cluster**: STMCLUSTER (192.168.100.50)
 **Domain**: stmtest.local
-**Admin**: stmtest.local\Install (P@ssw0rd1)
+**Admin**: stmtest.local\Install (password you set in `integration-test-config.json`)
 
 ## Scripts
 


### PR DESCRIPTION
## What
Replace the literal sample admin password (`P@ssw0rd1`) in the integration-test setup with an explicit placeholder.

- `integration-test-config.example.json`: `adminPassword` → `<choose-a-strong-password>`, plus a `_password_comment` noting Windows complexity rules and that the real `integration-test-config.json` is gitignored.
- `tests/Integration/README.md`: the **Admin** line now points to your gitignored config instead of printing a literal.
- `CHANGELOG.md`: one `### Changed` entry under `[Unreleased]`.

## Why
Surfaced during a GitGuardian incident sweep. Nothing live leaked — the real `integration-test-config.json` is gitignored, so this only touches the committed *example*. But shipping a realistic password literal in a public sample trips secret scanners and models weak-credential reuse.

## Notes
- No code/behavior change. CI integration auth uses separate `HYPERV_*` env vars, not this value.
- Pre-commit hooks (ggshield + mixed-line-ending) pass; commit is signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated integration test documentation and example configuration files. The default sample admin password is no longer shipped with the project; users are now required to provide and configure their own secure admin password in the configuration placeholder file, adhering to specified password complexity requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tablackburn/ScheduledTasksManager/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->