### PR TITLE
fix(build): harden the PSGallery source check to match the rest of the fleet

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -107,11 +107,29 @@ if ($Bootstrap) {
         # A repository named PSGallery is not necessarily the PowerShell Gallery. If one
         # is already registered against a different SourceLocation, every dependency in
         # build.depend.psd1 would be installed from it on the strength of the name alone.
-        # Refuse rather than trust the name.
-        $expectedSourceLocation = 'https://www.powershellgallery.com/api/v2'
-        $actualSourceLocation = $psGallery.SourceLocation.TrimEnd('/')
-        if ($actualSourceLocation -ne $expectedSourceLocation.TrimEnd('/')) {
-            throw "The repository named 'PSGallery' points at [$actualSourceLocation], not [$expectedSourceLocation]. Refusing to install build dependencies from an unexpected source."
+        #
+        # Compare the parsed URI's scheme, host and port rather than the string:
+        #
+        #   - String equality with -ne is case-insensitive, so a differently cased value
+        #     slipped through. Switching to -cne would be wrong in the other direction,
+        #     since host names are case-insensitive by definition and -cne would reject
+        #     https://WWW.PowerShellGallery.com/api/v2, which is the real gallery.
+        #   - Port matters: a non-default port on the same name reaches a different
+        #     listener. [Uri] supplies 443 for https when none is given, so the canonical
+        #     URL and an explicit :443 both match, while :444 does not.
+        #   - The path is deliberately not compared. The gallery serves both /api/v2 and
+        #     /api/v3, and any path on the genuine host is still the genuine host. Host
+        #     and port are the trust boundary; pinning the path would only add a false
+        #     rejection for a legitimate registration.
+        $expectedSource = [Uri]'https://www.powershellgallery.com/api/v2'
+        $actualSource = $psGallery.SourceLocation -as [Uri]
+        $sourceIsExpected = $null -ne $actualSource -and
+            $actualSource.Scheme -eq $expectedSource.Scheme -and
+            $actualSource.Host -eq $expectedSource.Host -and
+            $actualSource.Port -eq $expectedSource.Port
+        if (-not $sourceIsExpected) {
+            $expectedAuthority = '{0}://{1}:{2}' -f $expectedSource.Scheme, $expectedSource.Host, $expectedSource.Port
+            throw "The repository named 'PSGallery' points at [$($psGallery.SourceLocation)], which is not $expectedAuthority. Refusing to install build dependencies from an unexpected source."
         }
 
         if ($psGallery.InstallationPolicy -ne 'Trusted') {


### PR DESCRIPTION
This repository received the **original** version of the PSGallery source check. The four repositories it was later propagated to then improved it after review — so the origin was left behind with the weaker version.

## What was wrong with the original

```powershell
$actualSourceLocation = $psGallery.SourceLocation.TrimEnd('/')
if ($actualSourceLocation -ne $expectedSourceLocation.TrimEnd('/')) { throw ... }
```

| Problem | Consequence |
| --- | --- |
| `-ne` is case-insensitive | a differently cased source location passed |
| no port comparison | `https://www.powershellgallery.com:444/api/v2` passed — a different listener on the same name |
| `.TrimEnd('/')` on a null | null-reference error instead of a clean refusal |

`-cne` is **not** the fix: host names are case-insensitive by definition, so it would reject `https://WWW.PowerShellGallery.com/api/v2`, which is the real gallery.

## What it does now

Parses the source location and compares **scheme, host and port**:

```powershell
$expectedSource = [Uri]'https://www.powershellgallery.com/api/v2'
$actualSource = $psGallery.SourceLocation -as [Uri]
$sourceIsExpected = $null -ne $actualSource -and
    $actualSource.Scheme -eq $expectedSource.Scheme -and
    $actualSource.Host   -eq $expectedSource.Host -and
    $actualSource.Port   -eq $expectedSource.Port
```

| Source location | Accepted |
| --- | --- |
| `https://www.powershellgallery.com/api/v2` | yes |
| `https://WWW.PowerShellGallery.com/api/V2` | yes — host names are case-insensitive |
| `https://www.powershellgallery.com:443/api/v2` | yes — 443 is the https default |
| `https://www.powershellgallery.com/other-path` | yes — same host |
| `https://www.powershellgallery.com:444/api/v2` | **no** |
| `http://www.powershellgallery.com/api/v2` | **no** |
| `https://evil.example.com/api/v2` | **no** |
| `not-a-uri` | **no** |

The **path is deliberately not compared**: the gallery serves both `/api/v2` and `/api/v3`, and any path on the genuine host is still the genuine host. Host and port are the trust boundary.

## Scope

A targeted replacement of that block, not a file copy — this repository's build configuration has differed from the fleet before, so the block was swapped in place and the result verified byte-identical to the reference afterwards. `23+/5-`, `build.ps1` only.

After this, all six repositories carry the same check.

No `CHANGELOG.md` entry: build tooling, not user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1CarQG8VibNFxw4cN53Zs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of the PowerShell Gallery source URL.
  * Invalid URLs, unexpected hosts, schemes, or ports now stop dependency installation with a clear error.
  * Treats HTTPS URLs using the default or explicit port 443 consistently.
  * Ignores URL paths when validating the gallery authority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->