### PR TITLE
style: apply the analyzer's own formatter to the module source

### DIFF
--- a/ScheduledTasksManager/Private/ConvertTo-StmResultMessage.ps1
+++ b/ScheduledTasksManager/Private/ConvertTo-StmResultMessage.ps1
@@ -67,80 +67,80 @@ function ConvertTo-StmResultMessage {
         $TaskSchedulerCodes = @{
             # Success codes (SCHED_S_*)
             # Hex 0x00041300 = decimal 267008
-            267008 = @{
+            267008     = @{
                 Name      = 'SCHED_S_TASK_READY'
                 Message   = 'The task is ready to run at its next scheduled time'
                 IsSuccess = $true
             }
             # Hex 0x00041301 = decimal 267009
-            267009 = @{
+            267009     = @{
                 Name      = 'SCHED_S_TASK_RUNNING'
                 Message   = 'The task is currently running'
                 IsSuccess = $true
             }
             # Hex 0x00041302 = decimal 267010
-            267010 = @{
+            267010     = @{
                 Name      = 'SCHED_S_TASK_DISABLED'
                 Message   = 'The task will not run at the scheduled times because it has been disabled'
                 IsSuccess = $true
             }
             # Hex 0x00041303 = decimal 267011
-            267011 = @{
+            267011     = @{
                 Name      = 'SCHED_S_TASK_HAS_NOT_RUN'
                 Message   = 'The task has not yet run'
                 IsSuccess = $true
             }
             # Hex 0x00041304 = decimal 267012
-            267012 = @{
+            267012     = @{
                 Name      = 'SCHED_S_TASK_NO_MORE_RUNS'
                 Message   = 'There are no more runs scheduled for this task'
                 IsSuccess = $true
             }
             # Hex 0x00041305 = decimal 267013
-            267013 = @{
+            267013     = @{
                 Name      = 'SCHED_S_TASK_NOT_SCHEDULED'
                 Message   = 'One or more of the properties needed to run this task on a schedule have not been set'
                 IsSuccess = $true
             }
             # Hex 0x00041306 = decimal 267014
-            267014 = @{
+            267014     = @{
                 Name      = 'SCHED_S_TASK_TERMINATED'
                 Message   = 'The last run of the task was terminated by the user'
                 IsSuccess = $true
             }
             # Hex 0x00041307 = decimal 267015
-            267015 = @{
+            267015     = @{
                 Name      = 'SCHED_S_TASK_NO_VALID_TRIGGERS'
                 Message   = 'Either the task has no triggers or the existing triggers are disabled or not set'
                 IsSuccess = $true
             }
             # Hex 0x00041308 = decimal 267016
-            267016 = @{
+            267016     = @{
                 Name      = 'SCHED_S_EVENT_TRIGGER'
                 Message   = 'Event triggers do not have set run times'
                 IsSuccess = $true
             }
             # Hex 0x0004131B = decimal 267035
-            267035 = @{
+            267035     = @{
                 Name      = 'SCHED_S_SOME_TRIGGERS_FAILED'
                 Message   = 'The task is registered, but not all specified triggers will start the task'
                 IsSuccess = $true
             }
             # Hex 0x0004131C = decimal 267036
-            267036 = @{
+            267036     = @{
                 Name      = 'SCHED_S_BATCH_LOGON_PROBLEM'
                 Message   = 'The task is registered, but may fail to start. Batch logon privilege needs to be enabled for the task principal'
                 IsSuccess = $true
             }
             # Hex 0x00041325 = decimal 267045
-            267045 = @{
+            267045     = @{
                 Name      = 'SCHED_S_TASK_QUEUED'
                 Message   = 'The Task Scheduler service has asked the task to run'
                 IsSuccess = $true
             }
 
             # Error codes (SCHED_E_*)
-            6200 = @{
+            6200       = @{
                 Name      = 'SCHED_E_SERVICE_NOT_LOCALSYSTEM'
                 Message   = 'The Task Scheduler service must be configured to run in the System account to function properly'
                 IsSuccess = $false
@@ -471,11 +471,11 @@ function ConvertTo-StmResultMessage {
         if ($taskSchedulerMatch) {
             Write-Verbose "Found Task Scheduler code: $($taskSchedulerMatch.Name)"
             $meanings.Add([PSCustomObject]@{
-                Source       = 'TaskScheduler'
-                ConstantName = $taskSchedulerMatch.Name
-                Message      = $taskSchedulerMatch.Message
-                IsSuccess    = $taskSchedulerMatch.IsSuccess
-            })
+                    Source       = 'TaskScheduler'
+                    ConstantName = $taskSchedulerMatch.Name
+                    Message      = $taskSchedulerMatch.Message
+                    IsSuccess    = $taskSchedulerMatch.IsSuccess
+                })
         }
 
         # Parse HRESULT structure for additional information
@@ -508,11 +508,11 @@ function ConvertTo-StmResultMessage {
                 $isDuplicate = $meanings | Where-Object { $_.Message -eq $win32Message }
                 if (-not $isDuplicate) {
                     $meanings.Add([PSCustomObject]@{
-                        Source       = 'Win32'
-                        ConstantName = $null
-                        Message      = $win32Message
-                        IsSuccess    = -not $isFailure
-                    })
+                            Source       = 'Win32'
+                            ConstantName = $null
+                            Message      = $win32Message
+                            IsSuccess    = -not $isFailure
+                        })
                     Write-Verbose "Added Win32 translation: $win32Message"
                 }
             }
@@ -525,11 +525,11 @@ function ConvertTo-StmResultMessage {
             # Check if translation succeeded and message is not just the number
             if ($null -ne $win32Message -and $win32Message -ne $codeValue.ToString()) {
                 $meanings.Add([PSCustomObject]@{
-                    Source       = 'Win32'
-                    ConstantName = $null
-                    Message      = $win32Message
-                    IsSuccess    = $false
-                })
+                        Source       = 'Win32'
+                        ConstantName = $null
+                        Message      = $win32Message
+                        IsSuccess    = $false
+                    })
                 Write-Verbose "Added direct Win32 translation: $win32Message"
             }
         }
@@ -538,11 +538,11 @@ function ConvertTo-StmResultMessage {
         if ($codeValue -eq 0 -and $meanings.Count -eq 0) {
             Write-Verbose 'Adding success message for code 0'
             $meanings.Add([PSCustomObject]@{
-                Source       = 'Win32'
-                ConstantName = 'ERROR_SUCCESS'
-                Message      = 'The operation completed successfully'
-                IsSuccess    = $true
-            })
+                    Source       = 'Win32'
+                    ConstantName = 'ERROR_SUCCESS'
+                    Message      = 'The operation completed successfully'
+                    IsSuccess    = $true
+                })
         }
 
         # Build the result object

--- a/ScheduledTasksManager/Public/Get-StmClusteredScheduledTaskInfo.ps1
+++ b/ScheduledTasksManager/Public/Get-StmClusteredScheduledTaskInfo.ps1
@@ -243,7 +243,7 @@
         # The State property comes from ScheduledTaskObject (in ClusteredScheduledTask output)
         $isRunning = $taskStateString -eq 'Running'
         $hasLastRunTime = ($mergedHashtable.Keys -contains 'LastRunTime') -and
-                          ($null -ne $mergedHashtable['LastRunTime'])
+        ($null -ne $mergedHashtable['LastRunTime'])
         if ($isRunning -and $hasLastRunTime) {
             $runningDuration = (Get-Date) - $mergedHashtable['LastRunTime']
             $mergedHashtable['RunningDuration'] = $runningDuration

--- a/ScheduledTasksManager/Public/Get-StmScheduledTaskRun.ps1
+++ b/ScheduledTasksManager/Public/Get-StmScheduledTaskRun.ps1
@@ -305,10 +305,10 @@
                         "that do not have an ActivityId"
                     )
                     $eventsWithoutActivityId = @($taskEvents | Where-Object {
-                        $null -eq $_.ActivityId -and
-                        $_.RecordId -gt $startEvent.RecordId -and
-                        $_.RecordId -lt $endEvent.RecordId
-                    })
+                            $null -eq $_.ActivityId -and
+                            $_.RecordId -gt $startEvent.RecordId -and
+                            $_.RecordId -lt $endEvent.RecordId
+                        })
                     Write-Verbose (
                         "Found $($eventsWithoutActivityId.Count) event(s) without ActivityId for activity ID " +
                         "'$activityId' of task '$($currentTask.TaskName)'"
@@ -354,8 +354,8 @@
 
                     # Add the result code(s) - always as an array for consistent output type
                     $resultCodes = @($runDetails['EventXml'].Event.EventData.Data | Where-Object {
-                        $_.Name -eq 'ResultCode'
-                    } | Select-Object -ExpandProperty '#text' -Unique)
+                            $_.Name -eq 'ResultCode'
+                        } | Select-Object -ExpandProperty '#text' -Unique)
                     # Filter out null/empty values
                     $resultCodes = @($resultCodes | Where-Object { -not [string]::IsNullOrEmpty($_) })
 
@@ -375,8 +375,8 @@
 
                         # Translate result codes to human-readable messages
                         $runDetails['ResultMessage'] = @($resultCodes | ForEach-Object {
-                            ConvertTo-StmResultMessage -ResultCode $_
-                        })
+                                ConvertTo-StmResultMessage -ResultCode $_
+                            })
                         Write-Verbose (
                             "Translated $($runDetails['ResultMessage'].Count) ResultCode(s) for activity ID " +
                             "'$activityId' of task '$($currentTask.TaskName)'"


### PR DESCRIPTION
Stacked on #72 — based on `fix/analyzer-settings-single-source`, not `main`. GitHub retargets this to `main` automatically when #72 merges. Review #72 first.

## What this does

#72 points `PSScriptAnalyzerSettings.psd1` at the `CodeFormatting` preset PSScriptAnalyzer ships. Under those rules the module source reports **43 findings, 42 of them auto-fixable formatting**. This PR runs `Invoke-Formatter` with that same settings file over `ScheduledTasksManager/**/*.ps1` and writes back what it returns. Nothing else.

| | Before | After |
|---|---|---|
| `PSUseConsistentIndentation` | 29 | 0 |
| `PSAlignAssignmentStatement` | 13 | 0 |
| `PSUseShouldProcessForStateChangingFunctions` | 1 | 1 |
| **Total** | **43** | **1** |

Three files changed: `ConvertTo-StmResultMessage.ps1` (33), `Get-StmScheduledTaskRun.ps1` (8), `Get-StmClusteredScheduledTaskInfo.ps1` (1).

## The one finding left, deliberately

`PSUseShouldProcessForStateChangingFunctions` on `New-StmError` is **not** a formatting finding and there is no auto-fix for it. It is a design question: `New-*` is on the analyzer's state-changing verb list, but `New-StmError` only builds an `ErrorRecord` in memory — it changes nothing. The real fix is either `SupportsShouldProcess` (ceremony for a pure constructor) or a scoped suppression with a reason. Either is a behaviour decision that does not belong in a whitespace commit, so it is left alone here.

## Why the diff looks the way it does

Two hunks are worth a second look, because the configured rules ask for something a human would not have typed:

- `PSAlignAssignmentStatement` with `CheckHashtable = $true` pads the short keys in `$TaskSchedulerCodes` out to the width of the longest (`2147942401`), so `267008 =` becomes `267008     =`.
- `PSUseConsistentIndentation` re-indents the closing `})` of multi-line script blocks passed as arguments, and dedents the `-and` continuation in `Get-StmClusteredScheduledTaskInfo`.

Both are what the preset specifies. Flagging them because they are the hunks most likely to read as wrong at a glance.

## Verification

- `git diff -w` is **empty**. Every hunk is an equal number of insertions and deletions (33/33, 8/8, 1/1) — no whole-file rewrites, so no line-ending or encoding drift.
- **Encoding preserved, not normalised.** 14 of the 42 source files carry a UTF-8 BOM and 28 do not. Files are written with `[System.IO.File]::WriteAllText` using each file's *original* BOM state; the 28/14 split is byte-identical before and after, and no file gained or lost one. Microsoft warns that automatic corrections do not always preserve initial encoding, so this was checked at the byte level rather than assumed.
- **LF preserved.** `Invoke-Formatter` returns CRLF on Windows; output is normalised to `\n` before writing. `Set-Content` was deliberately not used — it emits CRLF and would have rewritten every line against `.gitattributes` (`* text=auto eol=lf`). Zero CRLF in the tree after, same as before.
- **No string literal changed.** Here-strings and multi-line strings are the usual casualty of a formatter. The non-ASCII byte count per file is identical before and after (including the 🤞 in a comment in `Get-StmScheduledTaskRun.ps1`), and `git diff -w` being empty covers the rest.
- **Behaviour unchanged.** Full unit suite via `./build.ps1 -Task Test`: **1431 passed, 0 failed, 4 skipped** — identical before and after. The build's own `ScriptAnalysis` task confirms the drop independently: `found 43 warning(s)` before, `found 1 warning(s)` after.

No `CHANGELOG.md` entry — formatting is not user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYDue8DiVLErK17PzEGnUL
